### PR TITLE
[fix]添加yolo_neck的type hints

### DIFF
--- a/mmdet/models/necks/yolo_neck.py
+++ b/mmdet/models/necks/yolo_neck.py
@@ -1,12 +1,15 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 # Copyright (c) 2019 Western Digital Corporation or its affiliates.
+from typing import List, Tuple
 
 import torch
 import torch.nn.functional as F
 from mmcv.cnn import ConvModule
 from mmengine.model import BaseModule
+from torch import Tensor
 
 from mmdet.registry import MODELS
+from mmdet.utils import ConfigType, OptConfigType, OptMultiConfig
 
 
 class DetectionBlock(BaseModule):
@@ -33,12 +36,13 @@ class DetectionBlock(BaseModule):
     """
 
     def __init__(self,
-                 in_channels,
-                 out_channels,
-                 conv_cfg=None,
-                 norm_cfg=dict(type='BN', requires_grad=True),
-                 act_cfg=dict(type='LeakyReLU', negative_slope=0.1),
-                 init_cfg=None):
+                 in_channels: int,
+                 out_channels: int,
+                 conv_cfg: OptConfigType = None,
+                 norm_cfg: ConfigType = dict(type='BN', requires_grad=True),
+                 act_cfg: ConfigType = dict(
+                     type='LeakyReLU', negative_slope=0.1),
+                 init_cfg: OptMultiConfig = None) -> None:
         super(DetectionBlock, self).__init__(init_cfg)
         double_out_channels = out_channels * 2
 
@@ -52,7 +56,7 @@ class DetectionBlock(BaseModule):
             out_channels, double_out_channels, 3, padding=1, **cfg)
         self.conv5 = ConvModule(double_out_channels, out_channels, 1, **cfg)
 
-    def forward(self, x):
+    def forward(self, x: Tensor) -> Tensor:
         tmp = self.conv1(x)
         tmp = self.conv2(tmp)
         tmp = self.conv3(tmp)
@@ -90,13 +94,14 @@ class YOLOV3Neck(BaseModule):
     """
 
     def __init__(self,
-                 num_scales,
-                 in_channels,
-                 out_channels,
-                 conv_cfg=None,
-                 norm_cfg=dict(type='BN', requires_grad=True),
-                 act_cfg=dict(type='LeakyReLU', negative_slope=0.1),
-                 init_cfg=None):
+                 num_scales: int,
+                 in_channels: List[int],
+                 out_channels: List[int],
+                 conv_cfg: OptConfigType = None,
+                 norm_cfg: ConfigType = dict(type='BN', requires_grad=True),
+                 act_cfg: ConfigType = dict(
+                     type='LeakyReLU', negative_slope=0.1),
+                 init_cfg: OptMultiConfig = None) -> None:
         super(YOLOV3Neck, self).__init__(init_cfg)
         assert (num_scales == len(in_channels) == len(out_channels))
         self.num_scales = num_scales
@@ -117,7 +122,7 @@ class YOLOV3Neck(BaseModule):
             self.add_module(f'detect{i+1}',
                             DetectionBlock(in_c + out_c, out_c, **cfg))
 
-    def forward(self, feats):
+    def forward(self, feats=Tuple[Tensor]) -> Tuple[Tensor]:
         assert len(feats) == self.num_scales
 
         # processed from bottom (high-lvl) to top (low-lvl)


### PR DESCRIPTION
## Motivation
超级视客营mmdet基础任务，选择链接中任一part代码添加type hints，为part9的yolo_neck.py添加type hints

## Modification
为yolo_neck.py中的DetectionBlock和YOLOV3Neck相关函数添加type hints

## Checklist

- [x] 1. Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] 2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] 3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
- [x] 4. The documentation has been modified accordingly, like docstring or example tutorials.
